### PR TITLE
Add GDAL + AWS CLI

### DIFF
--- a/buster/Dockerfile.node_14_16_0
+++ b/buster/Dockerfile.node_14_16_0
@@ -67,3 +67,5 @@ RUN set -ex \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   # smoke test
   && yarn --version
+
+RUN apt-get -y update && apt-get install -y gdal-bin

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -68,4 +68,8 @@ RUN set -ex \
   # smoke test
   && yarn --version
 
-RUN apt-get -y update && apt-get install -y postgresql-client
+RUN apt-get -y update && apt-get install -y postgresql-client gdal-bin
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install


### PR DESCRIPTION
# Summary of Changes
- Add GDAL to development + prod image for geospatial functionality
- Add AWS CLI so that SQL files can be pulled into local dev

# PR Creator Note
- Everyone will need to re-pull `pynode` to be able to work with the new backend changes.