### PR TITLE
Install libmemcached-dev library

### DIFF
--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8.3-buster
 
+RUN apt-get update && apt-get install -y libmemcached-dev
 RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestframework psycopg2 drf-extensions gunicorn
 
 RUN groupadd --gid 1000 node \


### PR DESCRIPTION
To support the installation of the `pylibmc` python module introduced in https://github.com/landedhomes/platform-backend-v2/pull/847