### PR TITLE
Add libmemcached-dev to `development`

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -68,7 +68,7 @@ RUN set -ex \
   # smoke test
   && yarn --version
 
-RUN apt-get -y update && apt-get install -y postgresql-client gdal-bin
+RUN apt-get -y update && apt-get install -y postgresql-client gdal-bin libmemcached-dev
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \


### PR DESCRIPTION
I had to rebuild my containers in localdev and discovered that this was missing (unable to install python requirements without it).

The starter repo uses `development`, not `latest` tag of `pynode`: https://github.com/landedhomes/landed-starter-repo/blob/main/.devcontainer/docker-compose.yml#L12

Related:
- https://github.com/landedhomes/platform-backend-v2/pull/859
- https://github.com/landedhomes/pynode/pull/4
