### PR TITLE
Add auth0 cli to our development image

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -73,3 +73,7 @@ RUN apt-get -y update && apt-get install -y postgresql-client gdal-bin libmemcac
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install
+
+RUN curl -L "https://github.com/auth0/auth0-cli/releases/download/v0.10.2/auth0-cli_0.10.2_Linux_x86_64.tar.gz" -o "auth0.tar.gz" \
+    && tar -xf auth0.tar.gz \
+    && mv auth0 /usr/local/bin


### PR DESCRIPTION
# Context
Our login page is managed by Auth0. The Auth0 template API is needed to edit the login template. Auth0 provides a CLI tool to
1. Pull the template to our default editor
2. Launch a storybook instance to view real time change
3. Save and push our template to Auth0.

This PR adds the Auth0 CLI into our local development environment.