### PR TITLE
Update python to 3.9.9 bullseye

### DIFF
--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.11-bullseye
+FROM python:3.9.9-bullseye
 
 RUN apt-get update && apt-get install -y libmemcached-dev
 RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestframework psycopg2 drf-extensions gunicorn

--- a/bullseye/Dockerfile.node_14_16_0
+++ b/bullseye/Dockerfile.node_14_16_0
@@ -1,4 +1,4 @@
-FROM python:3.8.11-bullseye
+FROM python:3.9.9-bullseye
 
 RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestframework psycopg2 drf-extensions gunicorn
 


### PR DESCRIPTION
# Context
Update base python version to 3.9.9. I'm running into some issue https://app.circleci.com/pipelines/github/landedhomes/platform-backend-v2/5640/workflows/ca36c0ae-0ae6-4fe0-935e-6125f00c509b/jobs/8014 because a function i'm using is specific to `3.9`. Our production + local environment is already at `3.9.9` and our CI should also be updated to reflect that as well (our `pynode:latest` is still at 3.8.8)

# PR Creator Note
- Will push an updated image to `dockerhub` once merged to `master`