### PR TITLE
Use Node 14.17.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # PyNode (Python + Node.js)
 
-Docker image containing Python (v3.8.3) and Node.js (v14.16.0) for full-stack application development.
+Docker image containing Python (v3.8.3) and Node.js (v14.17.6) for full-stack application development.

--- a/bullseye/Dockerfile.node_14_17_6
+++ b/bullseye/Dockerfile.node_14_17_6
@@ -1,11 +1,11 @@
-FROM python:3.8.3-buster
+FROM python:3.9.9-bullseye
 
 RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestframework psycopg2 drf-extensions gunicorn
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 14.16.0
+ENV NODE_VERSION 14.17.6
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -68,4 +68,4 @@ RUN set -ex \
   # smoke test
   && yarn --version
 
-RUN apt-get update --allow-releaseinfo-change && apt-get install -y gdal-bin libmemcached-dev
+RUN apt-get update && apt-get install -y gdal-bin libmemcached-dev

--- a/buster/Dockerfile.node_14_17_6
+++ b/buster/Dockerfile.node_14_17_6
@@ -1,11 +1,11 @@
-FROM python:3.9.9-bullseye
+FROM python:3.8.3-buster
 
 RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestframework psycopg2 drf-extensions gunicorn
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 14.16.0
+ENV NODE_VERSION 14.17.6
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -68,4 +68,4 @@ RUN set -ex \
   # smoke test
   && yarn --version
 
-RUN apt-get update && apt-get install -y gdal-bin libmemcached-dev
+RUN apt-get update --allow-releaseinfo-change && apt-get install -y gdal-bin libmemcached-dev

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install flake8 autopep8 pytest grpcio grpcio-tools django djangorestfram
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 14.16.0
+ENV NODE_VERSION 14.17.6
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Upgrading to the next minor version of Node unblocks the next major version upgrade for Create React App.

See also:
- https://www.notion.so/landedinc/Improve-frontend-local-development-dd756f854f854a74895efaef6fdcb3f4#0bbac90a0b4a45bba5f42cb5b154170e
- https://github.com/landedhomes/landed-agent/pull/858